### PR TITLE
Describe more endpoint mappings

### DIFF
--- a/content/uri-consolidation/index.md
+++ b/content/uri-consolidation/index.md
@@ -37,7 +37,10 @@ Endpoint mappings:
 * From `/record/{field-value}` to `/records/{field-value}`.
 * From `/record/{field-value}/entries` to `/records/{field-value}/entries`.
 * From `/entry/{entry-number}` to `/entries/{entry-number}`.
+* From `/entry/{entry-number}/proofs` to `/entries/{entry-number}/proofs`.
 * From `/item/{item-hash}` to `/items/{item-hash}`.
+* From `/proof/entry/{entry-number}/{total-entries}/{proof-identifier}` to
+`/proof/entries/{entry-number}/{total-entries}/{proof-identifier}`.
 
 Note that we have not yet implemented `/items`, but it is in the pipeline.
 


### PR DESCRIPTION
Signed-off-by: Arnau Siches <arnau.siches@digital.cabinet-office.gov.uk>

### Context

RFC0002 aims to consolidate the API URIs so they can be used more consistently when in CURIE form.

### Changes proposed in this pull request

Adds a few more URI mappings for subresources.