### PR TITLE
RFC0017: Full item redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ REST API).
 |0014|[Summary resource](content/summary-resource/index.md)|rejected|2018-08-24|#27|
 |0015|[Schema resource](content/schema-resource/index.md)|rejected|2018-08-22|#28|
 |0016|Blob resource|draft|-|#29|
-|0017|Full item redaction|draft|-|#30|
+|0017|[Full item redaction](content/full-item-redacted/index.md)|approved|2018-09-25|#30|
 |0018|Context resource|draft|-|#31|
 |0019|[Boolean datatype](content/boolean-datatype/index.md)|approved|2018-08-29|#32|
 |0020|[Blob normalisation](content/blob-normalisation/index.md)|approved|2018-09-07|#33|

--- a/content/full-item-redacted/index.md
+++ b/content/full-item-redacted/index.md
@@ -1,8 +1,9 @@
 ---
 rfc: 0017
 start_date: 2018-08-23
+decision_date: 2018-09-25
 pr: openregister/registers-rfcs#30
-status: draft
+status: approved
 ---
 
 # Full item redaction

--- a/content/full-item-redacted/index.md
+++ b/content/full-item-redacted/index.md
@@ -1,0 +1,90 @@
+---
+rfc: 0017
+start_date: 2018-08-23
+pr: openregister/registers-rfcs#30
+status: draft
+---
+
+# Full item redaction
+
+## Summary
+
+This RFC proposes a way to signal an item has been fully redacted.
+
+Dependencies:
+
+* [RFC0010: Item hash](https://github.com/openregister/registers-rfcs/pull/24).
+* [RFC0013: Multihash](https://github.com/openregister/registers-rfcs/pull/26).
+
+
+## Motivation
+
+The specification defines “redaction” as:
+
+> An item may be removed from a register, but the entry MUST NOT be removed
+> from the register.
+
+In some buried decision log and as a known thing for some components of the
+Registers core team, a while ago it was decided that to fully redact an item,
+the HTTP response would be a `410 Gone`. The specification doesn't reflect
+this decision nor the details.
+
+
+## Explanation
+
+A fully redacted item MUST respond with a `410 Gone` HTTP status keeping the
+same payload structure as a `200 OK` response but redacted following RFC0010
+`**REDACTED**` mark and strategy.
+
+Note: Partially redacted items are addressed by RFC0010.
+
+***
+**EXAMPLE:**
+
+For example,
+
+```http
+GET /items/sha-256:6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb HTTP/1.1
+Host: country.register.gov.uk
+Accept: application/json
+```
+
+```http
+HTTP/1.1 410 Gone
+Content-Type: application/json
+
+**REDACTED**sha-256:6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb
+```
+
+With RFC0013 in mind, this is the expected behaviour:
+
+
+```http
+GET /items/12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb HTTP/1.1
+Host: country.register.gov.uk
+Accept: application/json
+```
+
+```http
+HTTP/1.1 410 Gone
+Content-Type: application/json
+
+**REDACTED**12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb
+```
+
+For CSV, the payload MUST be the same as the expected list of attributes
+doesn't apply:
+
+```http
+GET /items/12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb HTTP/1.1
+Host: country.register.gov.uk
+Accept: text/csv;charset=UTF-8
+```
+
+```http
+HTTP/1.1 410 Gone
+Content-Type: text/csv;charset=UTF-8
+
+**REDACTED**12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb
+```
+***

--- a/content/full-item-redacted/index.md
+++ b/content/full-item-redacted/index.md
@@ -53,7 +53,7 @@ Accept: application/json
 HTTP/1.1 410 Gone
 Content-Type: application/json
 
-**REDACTED**sha-256:6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb
+"**REDACTED**sha-256:6b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb"
 ```
 
 With RFC0013 in mind, this is the expected behaviour:
@@ -69,7 +69,7 @@ Accept: application/json
 HTTP/1.1 410 Gone
 Content-Type: application/json
 
-**REDACTED**12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb
+"**REDACTED**12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb"
 ```
 
 For CSV, the payload MUST be the same as the expected list of attributes

--- a/content/full-item-redacted/index.md
+++ b/content/full-item-redacted/index.md
@@ -72,8 +72,7 @@ Content-Type: application/json
 "**REDACTED**12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb"
 ```
 
-For CSV, the payload MUST be the same as the expected list of attributes
-doesn't apply:
+For CSV, the response MUST be the same, in JSON:
 
 ```http
 GET /items/12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb HTTP/1.1
@@ -83,8 +82,36 @@ Accept: text/csv;charset=UTF-8
 
 ```http
 HTTP/1.1 410 Gone
-Content-Type: text/csv;charset=UTF-8
+Content-Type: application/json
 
-**REDACTED**12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb
+"**REDACTED**12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb"
 ```
 ***
+
+### Implications for records
+
+A record with a redacted item should inline the redacted item:
+
+
+```http
+GET /items/12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb HTTP/1.1
+Host: country.register.gov.uk
+Accept: text/csv;charset=UTF-8
+```
+
+```http
+HTTP/1.1 410 Gone
+Content-Type: application/json
+
+"**REDACTED**12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb"
+
+{
+  "GB": {
+    "index-entry-number": 6,
+    "entry-number": 6,
+    "entry-timestamp": "2016-04-05T13:23:05Z",
+    "key":"GB",
+    "item":["**REDACTED**12206b18693874513ba13da54d61aafa7cad0c8f5573f3431d6f1c04b07ddb27d6bb"]
+  }
+}
+```


### PR DESCRIPTION
### Context

The specification defines “redaction” as:

> An item may be removed from a register, but the entry MUST NOT be removed
> from the register.

In some buried decision log and as a known thing for some components of the
Registers core team, a while ago it was decided that to fully redact an item,
the HTTP response would be a `410 Gone`. The specification doesn't reflect
this decision nor the details.


### Changes proposed in this pull request

This RFC proposes a way to signal an item has been fully redacted.

Dependencies:

* [RFC0010: Item hash](https://github.com/openregister/registers-rfcs/pull/24).
* [RFC0013: Multihash](https://github.com/openregister/registers-rfcs/pull/26).