### PR TITLE
RFC0022: Facets endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ REST API).
 |0019|[Boolean datatype](content/boolean-datatype/index.md)|approved|2018-08-29|#32|
 |0020|[Blob normalisation](content/blob-normalisation/index.md)|approved|2018-09-07|#33|
 |0021|[Archive resource](content/archive-resource/index.md)|approved|2018-10-31|#35|
-|0022|Facets endpoint|draft||#39|
+|0022|[Facets endpoint](content/facets-endpoint/index.md)|approved||#39|
 |0023|[Proof resource](content/proof-resource/index.md)|approved|2018-10-31|#40|
 |0024|[Indexes removal](content/indexes-removal/index.md)|approved|2018-10-25|#41|
 |0025|Snapshot resource|draft||#42|

--- a/content/facets-endpoint/index.md
+++ b/content/facets-endpoint/index.md
@@ -1,9 +1,9 @@
 ---
 rfc: 0022
 start_date: 2018-09-28
-decision_date:
+decision_date: 2018-11-30
 pr: openregisters/registers-rfc#39
-status: draft
+status: approved
 ---
 
 # Facets endpoint

--- a/content/facets-endpoint/index.md
+++ b/content/facets-endpoint/index.md
@@ -50,7 +50,7 @@ records collection.
 GET /records{?name, value}
 ```
 
-Where `{?name}` is required if `{?value}` is informed.
+Where `{?name}` is required if `{?value}` is provided.
 
 
 ### Filter by strict value match
@@ -67,7 +67,7 @@ Exactly the current behaviour.
 GET /records?name={attribute-name}
 ```
 
-If the value of the given attribute name is informed (i.e. is not null) it
+If the value of the given attribute name is provided (i.e. is not null) it
 returns the record.
 
 ***

--- a/content/facets-endpoint/index.md
+++ b/content/facets-endpoint/index.md
@@ -1,0 +1,93 @@
+---
+rfc: 0022
+start_date: 2018-09-28
+decision_date:
+pr: openregisters/registers-rfc#39
+status: draft
+---
+
+# Facets endpoint
+
+## Summary
+
+This RFC proposes to change the endpoint for the records' “facets” to simplify
+path handling.
+
+## Motivation
+
+Currently the REST API for facets uses a path structure that overlaps with the
+standard record structure. This makes path handling (e.g. analytics, logging)
+harder than it needs to be. Observation suggests that users can get confused
+of what is the resource about.
+
+
+## Explanation
+
+For context, the current endpoint for facets is:
+
+```
+GET /records/{attribute-name}/{attribute-value}
+```
+
+The record endpoint is:
+
+```
+GET /records/{key}
+```
+
+And the records endpoint is:
+
+```
+GET /records
+```
+
+
+This RFC proposes to change the facets endpoint to extend the records endpoint
+with a query string to make more obvious that a “facet” is filter on the
+records collection.
+
+```
+GET /records{?name, value}
+```
+
+Where `{?name}` is required if `{?value}` is informed.
+
+
+### Filter by strict value match
+
+```
+GET /records?name={attribute-name}&value={attribute-value}
+```
+
+Exactly the current behaviour.
+
+### Filter by name
+
+```
+GET /records?name={attribute-name}
+```
+
+If the value of the given attribute name is informed (i.e. is not null) it
+returns the record.
+
+***
+**EXAMPLE:**
+
+For example, to get all records with an end date in the country register:
+
+```http
+GET /records?name=end-date HTTP/1.1
+Host: country.register.gov.uk
+Accept: application/json
+```
+***
+
+This RFC does not address the problem of querying the negated version of the
+above example.
+
+
+### Backwards compatibility
+
+In order to guarantee backwards compatibility and to have a smooth transition,
+the old endpoint should issue HTTP permanent redirects (301) to the new
+equivalents.

--- a/content/facets-endpoint/index.md
+++ b/content/facets-endpoint/index.md
@@ -13,6 +13,10 @@ status: draft
 This RFC proposes to change the endpoint for the records' “facets” to simplify
 path handling.
 
+The facets requirement is not essential for a Register to operate so this RFC
+proposes relaxing the specification and making its implementation optional.
+
+
 ## Motivation
 
 Currently the REST API for facets uses a path structure that overlaps with the
@@ -60,30 +64,6 @@ GET /records?name={attribute-name}&value={attribute-value}
 ```
 
 Exactly the current behaviour.
-
-### Filter by name
-
-```
-GET /records?name={attribute-name}
-```
-
-If the value of the given attribute name is provided (i.e. is not null) it
-returns the record.
-
-***
-**EXAMPLE:**
-
-For example, to get all records with an end date in the country register:
-
-```http
-GET /records?name=end-date HTTP/1.1
-Host: country.register.gov.uk
-Accept: application/json
-```
-***
-
-This RFC does not address the problem of querying the negated version of the
-above example.
 
 
 ### Backwards compatibility


### PR DESCRIPTION
### Context

Currently the REST API for facets uses a path structure that overlaps with the
standard record structure. This makes path handling (e.g. analytics, logging)
harder than it needs to be. Observation suggests that users can get confused
of what is the resource about.

### Changes proposed in this pull request

This RFC proposes to change the endpoint for the records' “facets” to simplify
path handling.